### PR TITLE
fix: skip bad markers on map

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -65,6 +65,7 @@
          * @see https://developers.google.com/maps/documentation/javascript/markers
          */
         function addMarkerToMap({place, id, url}) {
+          if (!place || !place.geometry) return; // bad place
           const marker = new google.maps.Marker({
             position: place.geometry.location,
             map,


### PR DESCRIPTION
This change prevents JS errors for a very small set of places that are geo-identifiable/mappable.
R: @averikitsch